### PR TITLE
adding changes caused by yeoman-test update

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "sinon": "^9.0.0",
     "strip-ansi": "^6.0.0",
     "yeoman-assert": "^3.1.0",
-    "yeoman-test": "^2.3.0"
+    "yeoman-test": "^2.6.0"
   },
   "engines": {
     "npm": ">= 4.0.0"
@@ -41,7 +41,7 @@
   "dependencies": {
     "chalk": "^2.1.0",
     "crypto-random-string": "^3.1.0",
-    "yeoman-generator": "^2.0.5",
+    "yeoman-generator": "^4.10.1",
     "yosay": "^2.0.1"
   },
   "eslintConfig": {

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -59,7 +59,7 @@ let _runner = async function ({
     .withPrompts(generatorPrompts)
     //at each run, the cwd stays tangled to previous base folder
     //we have to state the cwd explcitely to overcome this
-    .cd(cwd)
+    // .cd(cwd)
     .inDir("test-workspace");
   runner.on("ready", (generator) => {
     let genProt = Object.getPrototypeOf(generator);

--- a/tests/metadata.spec.js
+++ b/tests/metadata.spec.js
@@ -4,23 +4,23 @@ let metadata = require("../generators/app/util/metadata.js");
 let web = require("../generators/app/util/web.js");
 
 let get;
-test.beforeEach(t => {
+test.serial.beforeEach((t) => {
   let epack = "@babel/core";
   let npack = "unexisted";
   let field = "transpiler";
   let data = {
-    "data": JSON.stringify({
-      "_id": epack,
+    data: JSON.stringify({
+      _id: epack,
       "dist-tags": {
-        "latest": "7.8.4",
-        "release": "6.0.0-bridge.1"
-      }
+        latest: "7.8.4",
+        release: "6.0.0-bridge.1",
+      },
       //other data were redacted for clarity
     }),
-    "error": 0
-  }
+    error: 0,
+  };
 
-  //stubing the HTTP get method of web.js with fake 
+  //stubing the HTTP get method of web.js with fake
   //object 'withArgs' and 'withReturns'
 
   // issue submitted under
@@ -28,23 +28,23 @@ test.beforeEach(t => {
   // https://github.com/sinonjs/sinon/blob/6197ff34eefd021faa0ba14b05a4a543dcd407bc/lib/sinon/stub.js#L118-L132
   // stub retains references to the fakes even after restore
   // restore at each 'afterEach' clauses isn't enouth
-  get && get.restore()
+  get && get.restore();
   get = sin.stub(web, "get");
   get.withArgs(epack).resolves(data);
 
   t.context = {
-    "epack": epack,
-    "npack": npack,
-    "field": field
-  }
+    epack: epack,
+    npack: npack,
+    field: field,
+  };
 });
 
 //eslint-disable-next-line no-unused-vars
-test.afterEach(t=> {
+test.serial.afterEach((t) => {
   get.restore();
 });
 
-test("should call predicate if it is given a function", t => {
+test.serial("should call predicate if it is given a function", (t) => {
   let field = t.context.field;
   let epack = t.context.epack;
   let processor = sin.stub().returns(epack);
@@ -53,7 +53,7 @@ test("should call predicate if it is given a function", t => {
   t.true(get.called);
 });
 
-test("should produce question object for exisisting package", async t => {
+test.serial("should produce question object for exisisting package", async (t) => {
   let field = t.context.field;
   let processor = t.context.epack;
   let question = await metadata.getVersionQuestion({ field, processor });
@@ -63,16 +63,23 @@ test("should produce question object for exisisting package", async t => {
 
   let fakeInquirer = { [field]: processor };
   t.truthy(question.when(fakeInquirer));
-  t.is(question.message(fakeInquirer), "Which babelCore version would you preffer?");
+  t.is(
+    question.message(fakeInquirer),
+    "Which babelCore version would you preffer?"
+  );
 
   //check the object data for the choises
   let choices = question.choices(fakeInquirer);
   t.is(choices.length, 2);
   t.deepEqual(choices[0], { name: "v7.8.4", value: "7.8.4", short: "7.8.4" });
-  t.deepEqual(choices[1], { name: "v6.0.0-bridge.1", value: "6.0.0-bridge.1", short: "6.0.0-bridge.1" });
+  t.deepEqual(choices[1], {
+    name: "v6.0.0-bridge.1",
+    value: "6.0.0-bridge.1",
+    short: "6.0.0-bridge.1",
+  });
 });
 
-test('should produce a blank result if the package is an unexisted package', async t => {
+test.serial("should produce a blank result if the package is an unexisted package", async (t) => {
   sin.restore();
 
   let getUnexist = sin.stub(web, "get");
@@ -82,6 +89,7 @@ test('should produce a blank result if the package is an unexisted package', asy
 
   let processor = "unexisted";
   let result = await metadata.getVersionQuestion({ field, processor });
-  getUnexist.restore();
   t.falsy(result);
+
+  getUnexist.restore();
 });

--- a/tests/yo.config.spec.js
+++ b/tests/yo.config.spec.js
@@ -5,7 +5,7 @@ let sin = require("sinon");
 
 /**
  * Possible test cases
- * 
+ *
  * 1. what happens if there is no saved yeoman configurations available 😃
  * 2. what happens if ther is saved config                              😃
  *  3. # of configs in the stream                                       😃
@@ -14,72 +14,80 @@ let sin = require("sinon");
  *  6. test for the state management library inclusion  - @main
  */
 
-let inquirer = { 'state': false };
-let pollInquirer = (inquire) => inquire['transpiler'];
+let inquirer = { state: false };
+let pollInquirer = (inquire) => inquire["transpiler"];
 
 let verQueStub;
 let getAllReturnsData;
 let getAllReturnsEmpty;
 
 // eslint-disable-next-line no-unused-vars
-test.serial.beforeEach(t => {
+test.serial.beforeEach((t) => {
   let question = {
     name: "testName",
     type: "list",
     when: pollInquirer(inquirer),
     message: "dummy message",
-    choises: [{}, {}]
-  }
+    choises: [{}, {}],
+  };
   verQueStub && verQueStub.restore();
   verQueStub = sin.stub(metadata, "getVersionQuestion");
-  verQueStub.withArgs({ field: "transpiler", processor: "@babel/core" })
+  verQueStub
+    .withArgs({ field: "transpiler", processor: "@babel/core" })
     .resolves(question);
 
   getAllReturnsData = sin.fake.returns({
-    "linter": true,
-    "transpiler": true
+    linter: true,
+    transpiler: true,
   });
 
   getAllReturnsEmpty = sin.fake.returns({});
 });
 
 // eslint-disable-next-line no-unused-vars
-test.serial.afterEach(t => {
+test.serial.afterEach((t) => {
   //sin.match => research
   verQueStub.restore();
 });
 
-test.serial("Should contain a prompt for 'load previous configs'", async t => {
+test.serial(
+  "Should contain a prompt for 'load previous configs'",
+  async (t) => {
+    let result = await conf({ getAll: getAllReturnsData });
+    t.true(getAllReturnsData.called);
+    t.false(verQueStub.called);
+    let wrapper = Array.from(result);
+    let preConf = wrapper.find((prompt) => prompt["name"] === "previous");
+    t.truthy(preConf);
+    t.is(wrapper.length, 1);
+  }
+);
 
-  let result = await conf({ getAll: getAllReturnsData });
-  t.true(getAllReturnsData.called);
-  t.false(verQueStub.called);
-  let wrapper = Array.from(result);
-  let preConf = wrapper.find(prompt => prompt["name"] === "previous");
-  t.truthy(preConf);
-  t.is(wrapper.length, 1);
-});
+test.serial(
+  "Should not contain a prompt for 'load previous configs'",
+  async (t) => {
+    let result = await conf({ getAll: getAllReturnsEmpty });
+    t.true(getAllReturnsEmpty.called);
+    t.true(verQueStub.called);
 
-test.serial("Should not contain a prompt for 'load previous configs'", async t => {
-  
-  let result = await conf({ getAll: getAllReturnsEmpty });
-  t.true(getAllReturnsEmpty.called);
-  t.true(verQueStub.called);
+    let preConf = Array.from(result)
+      //need to filter this because sinon stab the function considering
+      //deep equality of the arguments of the original function
+      //because of that there will be undefined values could
+      //exists in returned result
+      .filter((p) => p !== undefined)
+      .find((prompt) => prompt["name"] === "previous");
+    t.falsy(preConf);
+  }
+);
 
-  let preConf = Array.from(result)
-    //need to filter this because sinon stab the function considering
-    //deep equality of the arguments of the original function
-    //because of that there will be undefined values could
-    //exists in returned result
-    .filter(p => p !== undefined)
-    .find(prompt => prompt["name"] === "previous");
-  t.falsy(preConf);
-});
-
-test.serial("Should contain 18 question items when there is no previous saved configs", async t=> {
-  let result = await conf({getAll: getAllReturnsEmpty});
-  t.true(getAllReturnsEmpty.called);
-  t.true(verQueStub.called);
-  let itemcount = Array.from(result).length;
-  t.is(itemcount, 18);
-});
+test.serial(
+  "Should contain 18 question items when there is no previous saved configs",
+  async (t) => {
+    let result = await conf({ getAll: getAllReturnsEmpty });
+    t.true(getAllReturnsEmpty.called);
+    t.true(verQueStub.called);
+    let itemcount = Array.from(result).length;
+    t.is(itemcount, 18);
+  }
+);


### PR DESCRIPTION
adding changes caused by updating yeoman-test constraint enforces to limit calling cd() or inDir() not both at a single execution.

1. bumped yeoman-test version and yeoman-generator version from 2.3.x - 2.6.x and 2.x.x to 4.x.x
2. adding `test.serial` for all the tests.
